### PR TITLE
Remove errant target from links.

### DIFF
--- a/twas_the_night_before_launch_day.md
+++ b/twas_the_night_before_launch_day.md
@@ -2,27 +2,27 @@
 
 Twas the night before Launchday, so I created a branch<br>
 to explore a new feature, without taking a chance<br>
-The master was safely checked into [Github](http://github.com/ "Github"){:target="_blank"} <br>
+The master was safely checked into [Github](http://github.com/ "Github") <br>
 So I felt fairly confident I would do nothing too dumb<br>
 
-With fresh user stories, in a new [Trello](http://trello.com/ "Trello"){:target="_blank"} board<br>
+With fresh user stories, in a new [Trello](http://trello.com/ "Trello") board<br>
 I set straight to hacking, upon my keyboard<br>
 The migrations were easy, and I kept my code DRY<br>
-When I found myself stymied I just opened [Pry](http://pryrepl.org "Pry"){:target="_blank"}<br>
+When I found myself stymied I just opened [Pry](http://pryrepl.org "Pry")<br>
 
 It was like this for hours, oh how the time flew<br>
 I was nearing completion before I even knew<br>
 So I ran the full test suite and prepared to submit<br>
-My newly born feature, pushed the branch up to [Git](https://git-scm.com "Git"){:target="_blank"}<br>
+My newly born feature, pushed the branch up to [Git](https://git-scm.com "Git")<br>
 
 The code was perfection, all the tests glowing green<br>
-And according to [Rubocop](http://batsov.com/rubocop/ "Rubocop"){:target="_blank"} , the formatting pristine<br>
+And according to [Rubocop](http://batsov.com/rubocop/ "Rubocop") , the formatting pristine<br>
 And the feature was working, time to submit a request<br>
 To pull this code into master, at a reviewers behest<br>
 
 With my pull request posted, I waited anxiously<br>
 To see my code merged into the master tree<br>
-When suddenly on [Slack](http://slack.com "Slack"){:target="_blank"} there arose such a clatter<br>
+When suddenly on [Slack](http://slack.com "Slack") there arose such a clatter<br>
 I read through the postings, to see what was the matter<br>
 
 The devs were all clacking, away at their keys<br>


### PR DESCRIPTION
Targeted links are not supported in Markdown. Might need another path.
